### PR TITLE
[ADD] 검색 창 레이아웃 구성

### DIFF
--- a/Quiet/Quiet.xcodeproj/project.pbxproj
+++ b/Quiet/Quiet.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		B51F1A1D28B5298B00B82CAD /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A1C28B5298B00B82CAD /* NSObject+Extension.swift */; };
 		B51F1A1F28B5299B00B82CAD /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A1E28B5299B00B82CAD /* UIViewController+Extension.swift */; };
 		B51F1A2128B52A0700B82CAD /* UITableView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A2028B52A0700B82CAD /* UITableView+Extension.swift */; };
+		B51F1A6828B6674600B82CAD /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A6728B6674600B82CAD /* BackButton.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,6 +45,7 @@
 		B51F1A1C28B5298B00B82CAD /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
 		B51F1A1E28B5299B00B82CAD /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		B51F1A2028B52A0700B82CAD /* UITableView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Extension.swift"; sourceTree = "<group>"; };
+		B51F1A6728B6674600B82CAD /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +96,7 @@
 		B51F1A0128B5276D00B82CAD /* Global */ = {
 			isa = PBXGroup;
 			children = (
+				B51F1A6628B666E800B82CAD /* UIComponents */,
 				B51F1A1128B5291700B82CAD /* Literals */,
 				B51F1A0528B5279A00B82CAD /* Utils */,
 				B51F1A0428B5278600B82CAD /* Extension */,
@@ -185,6 +188,14 @@
 			path = Literals;
 			sourceTree = "<group>";
 		};
+		B51F1A6628B666E800B82CAD /* UIComponents */ = {
+			isa = PBXGroup;
+			children = (
+				B51F1A6728B6674600B82CAD /* BackButton.swift */,
+			);
+			path = UIComponents;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -268,6 +279,7 @@
 				B51F19EF28B5276200B82CAD /* SceneDelegate.swift in Sources */,
 				B51F1A1728B5294F00B82CAD /* UIView+Constraints.swift in Sources */,
 				B51F1A1B28B5297500B82CAD /* UIColor+Extension.swift in Sources */,
+				B51F1A6828B6674600B82CAD /* BackButton.swift in Sources */,
 				B51F1A2128B52A0700B82CAD /* UITableView+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Quiet/Quiet.xcodeproj/project.pbxproj
+++ b/Quiet/Quiet.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		B51F1A2128B52A0700B82CAD /* UITableView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A2028B52A0700B82CAD /* UITableView+Extension.swift */; };
 		B51F1A6828B6674600B82CAD /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A6728B6674600B82CAD /* BackButton.swift */; };
 		B51F1A6B28B6714600B82CAD /* RecentKeywordTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A6A28B6714600B82CAD /* RecentKeywordTableViewCell.swift */; };
+		B51F1A6E28B6739900B82CAD /* RecentKeywordHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A6D28B6739900B82CAD /* RecentKeywordHeaderView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -48,6 +49,7 @@
 		B51F1A2028B52A0700B82CAD /* UITableView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Extension.swift"; sourceTree = "<group>"; };
 		B51F1A6728B6674600B82CAD /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
 		B51F1A6A28B6714600B82CAD /* RecentKeywordTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordTableViewCell.swift; sourceTree = "<group>"; };
+		B51F1A6D28B6739900B82CAD /* RecentKeywordHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordHeaderView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -168,6 +170,7 @@
 		B51F1A0828B527FB00B82CAD /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				B51F1A6C28B6738000B82CAD /* Component */,
 				B51F1A6928B6713000B82CAD /* Cell */,
 				B51F1A0D28B5283400B82CAD /* SearchViewController.swift */,
 			);
@@ -205,6 +208,14 @@
 				B51F1A6A28B6714600B82CAD /* RecentKeywordTableViewCell.swift */,
 			);
 			path = Cell;
+			sourceTree = "<group>";
+		};
+		B51F1A6C28B6738000B82CAD /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				B51F1A6D28B6739900B82CAD /* RecentKeywordHeaderView.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -280,6 +291,7 @@
 			files = (
 				B51F1A1F28B5299B00B82CAD /* UIViewController+Extension.swift in Sources */,
 				B51F1A1928B5296400B82CAD /* UIViewController+Alert.swift in Sources */,
+				B51F1A6E28B6739900B82CAD /* RecentKeywordHeaderView.swift in Sources */,
 				B51F19ED28B5276200B82CAD /* AppDelegate.swift in Sources */,
 				B51F1A6B28B6714600B82CAD /* RecentKeywordTableViewCell.swift in Sources */,
 				B51F1A1328B5292200B82CAD /* ImageLiteral.swift in Sources */,

--- a/Quiet/Quiet.xcodeproj/project.pbxproj
+++ b/Quiet/Quiet.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		B51F1A1F28B5299B00B82CAD /* UIViewController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A1E28B5299B00B82CAD /* UIViewController+Extension.swift */; };
 		B51F1A2128B52A0700B82CAD /* UITableView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A2028B52A0700B82CAD /* UITableView+Extension.swift */; };
 		B51F1A6828B6674600B82CAD /* BackButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A6728B6674600B82CAD /* BackButton.swift */; };
+		B51F1A6B28B6714600B82CAD /* RecentKeywordTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B51F1A6A28B6714600B82CAD /* RecentKeywordTableViewCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +47,7 @@
 		B51F1A1E28B5299B00B82CAD /* UIViewController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extension.swift"; sourceTree = "<group>"; };
 		B51F1A2028B52A0700B82CAD /* UITableView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Extension.swift"; sourceTree = "<group>"; };
 		B51F1A6728B6674600B82CAD /* BackButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackButton.swift; sourceTree = "<group>"; };
+		B51F1A6A28B6714600B82CAD /* RecentKeywordTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentKeywordTableViewCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -166,6 +168,7 @@
 		B51F1A0828B527FB00B82CAD /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				B51F1A6928B6713000B82CAD /* Cell */,
 				B51F1A0D28B5283400B82CAD /* SearchViewController.swift */,
 			);
 			path = Search;
@@ -194,6 +197,14 @@
 				B51F1A6728B6674600B82CAD /* BackButton.swift */,
 			);
 			path = UIComponents;
+			sourceTree = "<group>";
+		};
+		B51F1A6928B6713000B82CAD /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				B51F1A6A28B6714600B82CAD /* RecentKeywordTableViewCell.swift */,
+			);
+			path = Cell;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -270,6 +281,7 @@
 				B51F1A1F28B5299B00B82CAD /* UIViewController+Extension.swift in Sources */,
 				B51F1A1928B5296400B82CAD /* UIViewController+Alert.swift in Sources */,
 				B51F19ED28B5276200B82CAD /* AppDelegate.swift in Sources */,
+				B51F1A6B28B6714600B82CAD /* RecentKeywordTableViewCell.swift in Sources */,
 				B51F1A1328B5292200B82CAD /* ImageLiteral.swift in Sources */,
 				B51F1A1528B5293600B82CAD /* StringLiteral.swift in Sources */,
 				B51F1A1D28B5298B00B82CAD /* NSObject+Extension.swift in Sources */,

--- a/Quiet/Quiet/Global/Extension/UIViewController+Extension.swift
+++ b/Quiet/Quiet/Global/Extension/UIViewController+Extension.swift
@@ -8,6 +8,14 @@
 import UIKit
 
 extension UIViewController {
+    var screenWidth: CGFloat {
+        return UIScreen.main.bounds.size.width
+    }
+    
+    var screenHeight: CGFloat {
+        return UIScreen.main.bounds.size.height
+    }
+    
     func hideKeyboardWhenTappedAround() {
         let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         tap.cancelsTouchesInView = false

--- a/Quiet/Quiet/Global/Literals/ImageLiteral.swift
+++ b/Quiet/Quiet/Global/Literals/ImageLiteral.swift
@@ -9,9 +9,9 @@ import UIKit
 
 enum ImageLiteral {
     
-    // MARK: - icon
+    // MARK: - button
     
-    static var exampleIcon: UIImage { .load(name: "btnList") }
+    static var btnBack: UIImage { .load(systemName: "chevron.backward") }
 }
 
 extension UIImage {

--- a/Quiet/Quiet/Global/Literals/ImageLiteral.swift
+++ b/Quiet/Quiet/Global/Literals/ImageLiteral.swift
@@ -9,7 +9,7 @@ import UIKit
 
 enum ImageLiteral {
     
-    // MARK: - button
+    // MARK: - Button
     
     static var btnBack: UIImage { .load(systemName: "chevron.backward") }
 }

--- a/Quiet/Quiet/Global/Resources/Storyboard/Base.lproj/Main.storyboard
+++ b/Quiet/Quiet/Global/Resources/Storyboard/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21219" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21219" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zye-qo-EVb">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -23,6 +23,40 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="42" y="-2"/>
+        </scene>
+        <!--Search View Controller-->
+        <scene sceneID="NBN-IU-loT">
+            <objects>
+                <viewController storyboardIdentifier="SearchViewController" id="a6a-xo-IPg" customClass="SearchViewController" customModule="Quiet" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="0Qy-UR-PnT">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="YUz-s7-nj9"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="POa-D7-jdI"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qCE-L0-fXs" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2070.7692307692305" y="-2.1327014218009479"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="XSM-Q0-AZ9">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="zye-qo-EVb" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="gag-WN-fiK">
+                        <rect key="frame" x="0.0" y="47" width="390" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="a6a-xo-IPg" kind="relationship" relationship="rootViewController" id="HpQ-9K-kca"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ufJ-IT-eEg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1141.5384615384614" y="-2.1327014218009479"/>
         </scene>
     </scenes>
     <resources>

--- a/Quiet/Quiet/Global/UIComponents/BackButton.swift
+++ b/Quiet/Quiet/Global/UIComponents/BackButton.swift
@@ -1,0 +1,30 @@
+//
+//  BackButton.swift
+//  Quiet
+//
+//  Created by SHIN YOON AH on 2022/08/24.
+//
+
+import UIKit
+
+final class BackButton: UIButton {
+
+    // MARK: - init
+    
+    override init(frame: CGRect) {
+        super.init(frame: .init(origin: .zero, size: .init(width: 44, height: 44)))
+        configUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - func
+    
+    private func configUI() {
+        self.setImage(ImageLiteral.btnBack, for: .normal)
+        self.tintColor = .black
+        self.contentMode = .scaleToFill
+    }
+}

--- a/Quiet/Quiet/Global/UIComponents/BackButton.swift
+++ b/Quiet/Quiet/Global/UIComponents/BackButton.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class BackButton: UIButton {
 
-    // MARK: - init
+    // MARK: - Init
     
     override init(frame: CGRect) {
         super.init(frame: .init(origin: .zero, size: .init(width: 44, height: 44)))
@@ -20,7 +20,7 @@ final class BackButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - func
+    // MARK: - Func
     
     private func configUI() {
         self.setImage(ImageLiteral.btnBack, for: .normal)

--- a/Quiet/Quiet/Screens/Search/Cell/RecentKeywordTableViewCell.swift
+++ b/Quiet/Quiet/Screens/Search/Cell/RecentKeywordTableViewCell.swift
@@ -1,0 +1,20 @@
+//
+//  RecentKeywordTableViewCell.swift
+//  Quiet
+//
+//  Created by SHIN YOON AH on 2022/08/24.
+//
+
+import UIKit
+
+final class RecentKeywordTableViewCell: UITableViewCell {
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}

--- a/Quiet/Quiet/Screens/Search/Component/RecentKeywordHeaderView.swift
+++ b/Quiet/Quiet/Screens/Search/Component/RecentKeywordHeaderView.swift
@@ -1,0 +1,70 @@
+//
+//  RecentKeywordHeaderView.swift
+//  Quiet
+//
+//  Created by SHIN YOON AH on 2022/08/24.
+//
+
+import UIKit
+
+final class RecentKeywordHeaderView: UIView {
+    
+    // MARK: - properties
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "최근 검색한 지역"
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        return label
+    }()
+    private let removeButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("모두 지우기", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        button.setTitleColor(.gray, for: .highlighted)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .light)
+        return button
+    }()
+    private let separatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemGray5
+        return view
+    }()
+    
+    // MARK: - init
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+        configureUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - func
+    
+    private func setupLayout() {
+        addSubview(titleLabel)
+        titleLabel.constraint(leading: safeAreaLayoutGuide.leadingAnchor,
+                              bottom: bottomAnchor,
+                              padding: UIEdgeInsets(top: 0, left: 16, bottom: 20, right: 0))
+        
+        addSubview(removeButton)
+        removeButton.constraint(bottom: bottomAnchor,
+                                trailing: safeAreaLayoutGuide.trailingAnchor,
+                                padding: UIEdgeInsets(top: 0, left: 0, bottom: 12, right: 16))
+        
+        addSubview(separatorView)
+        separatorView.constraint(separatorView.heightAnchor, constant: 1)
+        separatorView.constraint(leading: leadingAnchor,
+                                 bottom: bottomAnchor,
+                                 trailing: trailingAnchor,
+                                 padding: .zero)
+    }
+    
+    private func configureUI() {
+        backgroundColor = .white
+    }
+}

--- a/Quiet/Quiet/Screens/Search/SearchViewController.swift
+++ b/Quiet/Quiet/Screens/Search/SearchViewController.swift
@@ -36,10 +36,29 @@ final class SearchViewController: UIViewController {
         textfield.returnKeyType = .search
         return textfield
     }()
+    private let separatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemGray5
+        return view
+    }()
+    
+    // MARK: - life cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupLayout()
         setupNavigationBar()
+    }
+    
+    // MARK: - func
+    
+    private func setupLayout() {
+        view.addSubview(separatorView)
+        separatorView.constraint(separatorView.heightAnchor, constant: 5)
+        separatorView.constraint(top: view.safeAreaLayoutGuide.topAnchor,
+                                 leading: view.leadingAnchor,
+                                 trailing: view.trailingAnchor,
+                                 padding: .zero)
     }
     
     private func setupNavigationBar() {

--- a/Quiet/Quiet/Screens/Search/SearchViewController.swift
+++ b/Quiet/Quiet/Screens/Search/SearchViewController.swift
@@ -14,7 +14,7 @@ final class SearchViewController: UIViewController {
         static let textFieldHeight = 44.0
     }
     
-    // MARK: - properties
+    // MARK: - Properties
     
     private lazy var backButton: UIButton = {
         let button = BackButton()
@@ -50,7 +50,7 @@ final class SearchViewController: UIViewController {
         return tableView
     }()
     
-    // MARK: - life cycle
+    // MARK: - Life cycle
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -58,7 +58,7 @@ final class SearchViewController: UIViewController {
         setupNavigationBar()
     }
     
-    // MARK: - func
+    // MARK: - Func
     
     private func setupLayout() {
         view.addSubview(separatorView)

--- a/Quiet/Quiet/Screens/Search/SearchViewController.swift
+++ b/Quiet/Quiet/Screens/Search/SearchViewController.swift
@@ -7,23 +7,57 @@
 
 import UIKit
 
-class SearchViewController: UIViewController {
+final class SearchViewController: UIViewController {
+    
+    private enum Size {
+        static let textFieldWidth = UIScreen.main.bounds.size.width - 64
+        static let textFieldHeight = 44.0
+    }
+    
+    // MARK: - properties
+    
+    private lazy var backButton: UIButton = {
+        let button = BackButton()
+        let buttonAction = UIAction { [weak self] _ in
+            self?.dismiss(animated: true)
+        }
+        button.addAction(buttonAction, for: .touchUpInside)
+        return button
+    }()
+    private let searchTextField: UITextField = {
+        let textfield = UITextField(frame: CGRect(origin: .zero,
+                                                  size: CGSize(width: Size.textFieldWidth, height: Size.textFieldHeight)))
+        textfield.placeholder = "지역구 혹은 동을 입력해주세요"
+        textfield.font = .systemFont(ofSize: 18, weight: .medium)
+        textfield.borderStyle = .none
+        textfield.clearButtonMode = .whileEditing
+        textfield.autocorrectionType = .no
+        textfield.autocapitalizationType = .none
+        textfield.returnKeyType = .search
+        return textfield
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        setupNavigationBar()
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    private func setupNavigationBar() {
+        let leftOffsetBackButton = removeBarButtonItemOffset(with: backButton, offsetX: 10)
+        let backButton = makeBarButtonItem(with: leftOffsetBackButton)
+        let searchTextField = makeBarButtonItem(with: searchTextField)
+        
+        navigationItem.leftBarButtonItems = [backButton, searchTextField]
     }
-    */
 
+    private func makeBarButtonItem<T: UIView>(with view: T) -> UIBarButtonItem {
+        return UIBarButtonItem(customView: view)
+    }
+    
+    private func removeBarButtonItemOffset(with button: UIButton, offsetX: CGFloat = 0, offsetY: CGFloat = 0) -> UIView {
+        let offsetView = UIView(frame: CGRect(x: 0, y: 0, width: 45, height: 45))
+        offsetView.bounds = offsetView.bounds.offsetBy(dx: offsetX, dy: offsetY)
+        offsetView.addSubview(button)
+        return offsetView
+    }
 }

--- a/Quiet/Quiet/Screens/Search/SearchViewController.swift
+++ b/Quiet/Quiet/Screens/Search/SearchViewController.swift
@@ -43,6 +43,7 @@ final class SearchViewController: UIViewController {
     }()
     private lazy var searchTableView: UITableView = {
         let tableView = UITableView()
+        tableView.sectionHeaderTopPadding = 0
         tableView.delegate = self
         tableView.dataSource = self
         tableView.register(cell: RecentKeywordTableViewCell.self)
@@ -109,5 +110,12 @@ extension SearchViewController: UITableViewDataSource {
 
 // MARK: - UITableViewDelegate
 extension SearchViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        let headerView = RecentKeywordHeaderView()
+        return headerView
+    }
     
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 66
+    }
 }

--- a/Quiet/Quiet/Screens/Search/SearchViewController.swift
+++ b/Quiet/Quiet/Screens/Search/SearchViewController.swift
@@ -41,6 +41,13 @@ final class SearchViewController: UIViewController {
         view.backgroundColor = .systemGray5
         return view
     }()
+    private lazy var searchTableView: UITableView = {
+        let tableView = UITableView()
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(cell: RecentKeywordTableViewCell.self)
+        return tableView
+    }()
     
     // MARK: - life cycle
 
@@ -59,6 +66,13 @@ final class SearchViewController: UIViewController {
                                  leading: view.leadingAnchor,
                                  trailing: view.trailingAnchor,
                                  padding: .zero)
+        
+        view.addSubview(searchTableView)
+        searchTableView.constraint(top: separatorView.bottomAnchor,
+                                   leading: view.leadingAnchor,
+                                   bottom: view.bottomAnchor,
+                                   trailing: view.trailingAnchor,
+                                   padding: .zero)
     }
     
     private func setupNavigationBar() {
@@ -79,4 +93,21 @@ final class SearchViewController: UIViewController {
         offsetView.addSubview(button)
         return offsetView
     }
+}
+
+// MARK: - UITableViewDataSource
+extension SearchViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 10
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: RecentKeywordTableViewCell.className, for: indexPath)
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+extension SearchViewController: UITableViewDelegate {
+    
 }


### PR DESCRIPTION
## 🍏 관련 이슈
<!-- 해당 PR과 관련된 이슈를 링크해주세요. -->
- close #3 

## 🍏 작업내용
<!-- 작업 내용과 이미지를 첨부해주세요. -->
검색 창 레이아웃을 구성했습니다.

- 하다보니 검색창, 검색결과창, 상세결과창에 backButton이 동일하게 들어갈 거 같아서 이 부분 때문에 BaseViewController를 만들면 어떨까 싶더라구요. 다른 분들은 어떻게 생각하시는지 의견을 묻고 싶습니다!
- `BackButton`를 UIComponent로 만들었습니다.
- 디자인에서 UIColor를 기본 컬러로 사용해서 굳이 UIColor+Extension를 만들 필요가 없을 거 같아요. 이 부분도 얘기 나누면 좋을 거 같습니다.
- backButton과 textField는 navigationBar에 item으로 넣었습니다.

![스크린샷 2022-08-25 오전 12 15 05](https://user-images.githubusercontent.com/55099365/186456176-c6808645-6229-4b64-96f1-8901c71f966a.png)


## 🍏 다음으로 진행될 작업
<!-- - [ ] 다음으로 할 일을 적어주세요. -->
 - [ ] 검색을 했을 시에 검색 결과가 쌓이는 로직 구현
 - [ ] 검색 결과 뷰 레이아웃 구현

## 🍏 주의사항
- **빈 폴더 있는지 확인하기!!**
- **파일,폴더 위치 및 이동 하지말기!!**
